### PR TITLE
fixed exit-process code

### DIFF
--- a/src/ClusterPingPong/src/Akka.ClusterPingPong/AkkaService.cs
+++ b/src/ClusterPingPong/src/Akka.ClusterPingPong/AkkaService.cs
@@ -33,9 +33,10 @@ namespace Akka.ClusterPingPong
 
         public IActorRef BenchmarkHostRouter {get; private set;}
 
-        public AkkaService(IServiceProvider serviceProvider)
+        public AkkaService(IServiceProvider serviceProvider, IHostApplicationLifetime lifetime)
         {
             _serviceProvider = serviceProvider;
+            _lifetime = lifetime;
         }
 
         public Task StartAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Forgot to actually pass in the `IHostApplicationLifetime` via DI, so #2 generated a `NullReferenceException` after the `ActorSystem` was removed from the cluster. This has been fixed.