### PR TITLE
`BenchmarkCoordinator` cleanup

### DIFF
--- a/src/ClusterPingPong/src/Akka.ClusterPingPong/Actors/BenchmarkCoordinator.cs
+++ b/src/ClusterPingPong/src/Akka.ClusterPingPong/Actors/BenchmarkCoordinator.cs
@@ -265,10 +265,9 @@ namespace Akka.ClusterPingPong.Actors
 
             Console.WriteLine("OSVersion:                         {0}", Environment.OSVersion);
             Console.WriteLine("ProcessorCount:                    {0}", processorCount);
-            Console.WriteLine("Actor Count:                       {0}", processorCount * 2);
             Console.WriteLine("Node Count:                        {0}", _participatingNodes.Count);
             Console.WriteLine("Active Connections:                {0}", Stats.Count);
-            Console.WriteLine("Msgs sent/received per connection: {0}  ({0:0e0})", MESSAGES_PER_PAIR * 2);
+            Console.WriteLine("Msgs sent/received per actor:      {0}  ({0:0e0})", MESSAGES_PER_PAIR * 2);
             Console.WriteLine("Is Server GC:                      {0}", GCSettings.IsServerGC);
             Console.WriteLine("Thread count per node:             {0}", Process.GetCurrentProcess().Threads.Count);
             Console.WriteLine();

--- a/src/ClusterPingPong/src/Akka.ClusterPingPong/Actors/BenchmarkCoordinator.cs
+++ b/src/ClusterPingPong/src/Akka.ClusterPingPong/Actors/BenchmarkCoordinator.cs
@@ -221,9 +221,12 @@ namespace Akka.ClusterPingPong.Actors
                     var totalMsg = Stats.Sum(x => x.Value.stats.ReceivedMessages) * 2;
                     var avgDuration = new TimeSpan((long)Stats.Average(x => x.Value.stats.Elapsed.Ticks));
                     var msgS = (long)(totalMsg / avgDuration.TotalSeconds);
-
+                    
+                    
                     // "Connections, Actors/node, Total [actor], Total [msg], Msgs/sec, Total [ms]"
-                    Console.WriteLine("{0, 8}, {1,8}, {2,8}, {3,10:N0}, {4,10:N0}, {5,10}", nodes, actors, total, totalMsg, msgS, avgDuration.TotalMilliseconds.ToString("F2", CultureInfo.InvariantCulture));
+                    Console.WriteLine("{0, 8}, {1,8}, {2,14}, {3,12:N0}, {4,10:N0}, {5,10}, {6,4}", nodes, actors, total, totalMsg, msgS, 
+                    avgDuration.TotalMilliseconds.ToString("F2", CultureInfo.InvariantCulture),
+                     Process.GetCurrentProcess().Threads.Count);
 
                     BenchmarkHostRouter.Tell(new RoundComplete());
                     _currentRound++;
@@ -232,7 +235,7 @@ namespace Akka.ClusterPingPong.Actors
                         Console.WriteLine("Benchmark complete");
                         foreach (var node in _participatingNodes)
                         {
-                            Cluster.Down(node);
+                            Cluster.Leave(node);
                         }
                     }
                     else
@@ -273,7 +276,7 @@ namespace Akka.ClusterPingPong.Actors
             Console.WriteLine();
 
             //Print tables
-            Console.WriteLine("Connections, Actors/node, Total [actor], Total [msg], Msgs/sec, Total [ms]");
+            Console.WriteLine("Connections, Actors/node, Total [actor], Total [msg], Msgs/sec, Total [ms], Threads");
         }
 
         protected override void PreStart(){

--- a/src/ClusterPingPong/src/Akka.ClusterPingPong/Actors/BenchmarkRoundHost.cs
+++ b/src/ClusterPingPong/src/Akka.ClusterPingPong/Actors/BenchmarkRoundHost.cs
@@ -115,8 +115,9 @@ namespace Akka.ClusterPingPong.Actors
                     {
                         foreach (var s in Stats.Values)
                         {
+                            var emptystats = new RoundStats(){ Pingee = s[0].Pingee, Pinger = s[0].Pinger };
                             // need to merge data for all distinct pairs together
-                            var merged = s.Aggregate(s[0], (s1, rounds) =>
+                            var merged = s.Aggregate(emptystats, (s1, rounds) =>
                             {
                                 return s1 = s1 with
                                 {


### PR DESCRIPTION
* Properly spaced all output
* Added header for `Threads`
* Threadcount is now determined by `Process.GetCurrentProcess().Threads.Count`, which measures the presence of all threads and not just those managed by the `ThreadPool`
* Have all nodes leave via `Cluster.Leave` rather than `Cluster.Down` once the benchmark is complete.