### PR TITLE
set `ThreadPool.MinThreads(0,0)`

### DIFF
--- a/src/ClusterPingPong/src/Akka.ClusterPingPong/Actors/BenchmarkCoordinator.cs
+++ b/src/ClusterPingPong/src/Akka.ClusterPingPong/Actors/BenchmarkCoordinator.cs
@@ -224,9 +224,9 @@ namespace Akka.ClusterPingPong.Actors
                     
                     
                     // "Connections, Actors/node, Total [actor], Total [msg], Msgs/sec, Total [ms]"
-                    Console.WriteLine("{0, 8}, {1,8}, {2,14}, {3,12:N0}, {4,10:N0}, {5,10}, {6,4}", nodes, actors, total, totalMsg, msgS, 
+                    Console.WriteLine("{0, 8}, {1,8}, {2,14}, {3,12:N0}, {4,10:N0}, {5,10}, [{6,4} -> {7}]", nodes, actors, total, totalMsg, msgS, 
                     avgDuration.TotalMilliseconds.ToString("F2", CultureInfo.InvariantCulture),
-                     Process.GetCurrentProcess().Threads.Count);
+                     System.Threading.ThreadPool.ThreadCount, Process.GetCurrentProcess().Threads.Count);
 
                     BenchmarkHostRouter.Tell(new RoundComplete());
                     _currentRound++;

--- a/src/ClusterPingPong/src/Akka.ClusterPingPong/AkkaService.cs
+++ b/src/ClusterPingPong/src/Akka.ClusterPingPong/AkkaService.cs
@@ -54,6 +54,10 @@ namespace Akka.ClusterPingPong
             // merge this setup (and any others) together into ActorSystemSetup
             var actorSystemSetup = bootstrap.And(diSetup);
 
+            ThreadPool.GetMinThreads(out var workerThreads, out var completionThreads);
+            Console.WriteLine("Min threads: {0}, Min I/O threads: {1}", workerThreads, completionThreads);
+            ThreadPool.SetMinThreads(0, 0);
+
             // start ActorSystem
             _clusterSystem = ActorSystem.Create("ClusterSys", actorSystemSetup);
 
@@ -69,7 +73,7 @@ namespace Akka.ClusterPingPong
                 singletonManagerPath: "/user/coordinator",
                 settings: ClusterSingletonProxySettings.Create(_clusterSystem)), "coordinator-proxy");
 
-            BenchmarkHost = _clusterSystem.ActorOf(Props.Create(() => new BenchmarkHost(BenchmarkCoordinator)), "host");
+            BenchmarkHost = _clusterSystem.ActorOf(Props.Create(() => new BenchmarkHost(BenchmarkCoordinator)), "host");           
 
             Akka.Cluster.Cluster.Get(_clusterSystem).RegisterOnMemberRemoved(() => {
                 _lifetime.StopApplication(); // when the ActorSystem terminates, terminate the process


### PR DESCRIPTION
Dramatic performance improvement that we want to carry over to Akka.NET itself